### PR TITLE
Rozlišení hlavičky stránky od zbytku obsahu na mobilních obrazovkách.

### DIFF
--- a/design/core-elements.css
+++ b/design/core-elements.css
@@ -360,6 +360,11 @@ a.button.green {
 	background-color: #0e8420;
 }
 
+a.button.grey {
+	color: #333;
+	background-color: #eee;
+}
+
 a.button:hover {
 	background-color: #f63;
 	text-decoration: inherit;
@@ -367,6 +372,11 @@ a.button:hover {
 
 a.button.green:hover {
 	background-color: #095615;
+}
+
+a.button.grey:hover {
+	color: #000;
+	background-color: #ddd;
 }
 
 a.button:after {
@@ -732,6 +742,21 @@ ol.releases li.past .baloon {
 	font-size: 16px;
 	line-height: 1.5;
 	font-weight: 300;
+}
+
+.rss-feed .credits-wrapper {
+	text-align: center;
+}
+
+.rss-feed .credits-wrapper .credits {
+	display: inline-block;
+	margin: 10px;
+	white-space: nowrap;
+}
+
+.rss-feed .credits-wrapper a.alternate {
+	margin: 0px 20px;
+	cursor: pointer;
 }
 
 .loading-overlay {

--- a/design/style.css
+++ b/design/style.css
@@ -237,8 +237,15 @@ section.hero .intro.text-white a.text {
 		height: auto;
 	}
 
-	section.hero .intro.text-white {
+	section.hero .intro, section.hero .intro.text-white, section.hero .intro.transparent {
+		background: #333;
+		color: #fff;
+	}
+
+	nav + main section.hero .intro, nav + main section.hero .intro.text-white, nav + main section.hero .intro.transparent {
+		background: #efefef;
 		color: #333;
+		border-bottom: 4px solid #ddd;
 	}
 }
 


### PR DESCRIPTION
Ahoj,
přidávám malý update, který snad trošku zlepší mobilní experience, a který jsem ještě v mezičase na své pískoviště na iubuntu.cz přidal.

Úpravy core-elements.css s tímhle úplně nesouvisejí, ale můžou se hodit, zvláště pak pokud se někde na webu použije pro překlady Yandex. A když ne, tak lze ocenit minimálně možnost použití nejen oranžových a zelených, ale nově i šedých tlačítek :).