### PR TITLE
Lepší překlady

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -111,22 +111,35 @@ layout: default
 	<div class="wrapper">
 		<article class="padded info">
 			<h2>Vaše oblíbené aplikace a služby k dispozici</h2>
-      {% include apps-games-overview.html %}
+			{% include apps-games-overview.html %}
 		</article>
 	</div>
 </section>
 
-<script src="{{ 'design/translator.js' | relative_url }}"></script>
+<script src="{{ 'design/translator/generic.js' | relative_url }}"></script>
 <script>
-  const translator = new ENCZTranslator({
-    capitalizeFirst: true,
-    dataLocation: "{{ 'design/translator/data.json' | relative_url }}"
-  });
-  [...document.querySelectorAll('.translate .rss-feed h3 a')].forEach(titleLink => {
-    translator.translate(titleLink.textContent).then((response) => {
-      titleLink.textContent = response;
-    }).catch((error) => {
-      console.error(error, 'Could not fetch translations from Translator.js');
-    });
-  });
+	const translator = new Translator({
+		engine: 'yandex'
+	});
+	[...document.querySelectorAll('.translate .rss-feed h3 a')].forEach(titleLink => {
+		translator.translate(titleLink.textContent).then((response) => {
+			if(response.text) {
+				titleLink.textContent = response.text;
+				
+				const container = titleLink.closest('.rss-feed');
+				if(container && response.credits && !container.querySelector('.credits-wrapper')) {
+					const creditsWrapper = document.createElement('div');
+					creditsWrapper.classList.add('credits-wrapper');
+					container.appendChild(creditsWrapper);
+					
+					const credits = document.createElement('span');
+					credits.classList.add('credits');
+					credits.innerHTML = response.credits;
+					creditsWrapper.appendChild(credits);
+				}
+			}
+		}).catch((error) => {
+			console.error(error, 'Could not fetch translations');
+		});
+	});
 </script>

--- a/design/translator/data.json
+++ b/design/translator/data.json
@@ -60,8 +60,7 @@
 	},
 	"names": {
 		"Europe": "\\!Evropa",
-		"London": "\\!Londýn",
-		"Life Is Strange: Before the Storm": "Lif\\e I\\s Strang\\e: Befor\\e th\\e Stor\\m"
+		"London": "\\!Londýn"
 	},
 	"currencies": {
 		"^\\$([\\d]+)": "$2 dolarový",

--- a/design/translator/generic.js
+++ b/design/translator/generic.js
@@ -1,0 +1,168 @@
+"use strict";
+
+/*
+ * Generic Translator
+ * 
+ * Allows to translate using multipe compatible engines
+ * currently works with the following engines:
+ * 	- default (local translations, regex-based, ideal for repetitive translations, mainly dates, days)
+ * 	- google (requires Google Api key and allowed access)
+ * 	- yandex (easy to set-up but requires displaying credits)
+ * 	- if a script path is provided Translator will assume there is a custom translator there and will try to use it.
+ * 	- alternatively an instance of some translator can be passed using loadedTranslator option.
+ * 
+ * Engine class name must match "TranslationService", or an existing already loaded instance has to be provided on initialization.
+ * 
+ * If no engine is specified default will be used.
+ * Used translators will be loaded automatically if present in the same directory. If not found, default will be used. If default is missing, no translations will be provided.
+ */
+
+class Translator {
+	constructor(data) {
+		data = data || {};
+		this.engine = data.engine || "default";
+		this.loadedTranslator = data.loadedTranslator || null;
+		if(this.loadedTranslator) {
+			this.engine = "custom instance";
+		}
+		this.scriptsPath = data.scriptsPath || "design/translator/";
+		
+		this.sourceLanguage = data.sourceLanguage || "en";
+		this.destinationLanguage = data.destinationLanguage || "cs";
+		
+		this.ready = false;
+		this.resolves = [];
+	}
+	
+	availableTranslators() {
+		return {
+			default: {
+				path: this.scriptsPath + "local-translator.js"
+			},
+			google: {
+				path: this.scriptsPath + "google-translator.js",
+				apiKey: null
+			},
+			yandex: {
+				path: this.scriptsPath + "yandex-translator.js",
+				apiKey: "trnsl.1.1.20190204T213725Z.9709ed8c8986727b.302abc56d72c7343ae9d3a2405dd4c0ba63a1b53"
+			},
+		}
+	}
+	
+	load(translator) {
+		this.loadInProgress = true;
+		return new Promise((resolve, reject) => {
+			let meta = this.availableTranslators()[translator];
+			if(!meta) {
+				if(meta.match(/\.js/)) {
+					this.engine = "custom script path";
+					meta = translator;
+				}
+				else {
+					console.error("[Translator] Invalid translator definition provided", translator);
+					reject(translator);
+				}
+			}
+			this.ready = false;
+			
+			let script = document.createElement("script");
+			
+			script.addEventListener("load", (event) => {
+				this.loadedTranslator = new TranslationService({
+					apiKey: (meta && meta.apiKey ? meta.apiKey : null),
+					scriptsPath: this.scriptsPath || null,
+					sourceLanguage: this.sourceLanguage,
+					destinationLanguage: this.destinationLanguage
+				});
+				for(let i = 0; i < this.resolves.length; i++) {
+					this.resolves[i].resolve();
+				}
+				this.resolves = [];
+				this.ready = true;
+				this.loadInProgress = false;
+				resolve(translator);
+			});
+			
+			script.addEventListener("error", (event) => {
+				console.error("[Translator] Could not load translator", translator);
+				for(let i = 0; i < this.resolves.length; i++) {
+					this.resolves[i].reject();
+				}
+				this.resolves = [];
+				this.loadInProgress = false;
+				reject(translator);
+			});
+			
+			script.src = meta ? meta.path : "";
+			
+			document.head.appendChild(script);
+		});
+	}
+	
+	onReady() {
+		return new Promise((resolve, reject) => {
+			if(this.ready) {
+				resolve();
+			}
+			else {
+				this.resolves.push({
+					resolve,
+					reject
+				});
+			}
+		});
+	}
+	
+	/*
+	 * Abstract translate method - every translator needs to implement this and return a promise with a respective translation
+	 * 
+	 * Tools need to implement the following:
+	 * resolve({
+			text: REPLY, // mandatory, contains translated string
+			lang: LANG_CODE, // optional, contains source language code, or a combination of source-destination (divided using dash character)
+			cached: BOOL, // optional, informing whether the reply has been newly fetched or already taken from a cache. Cache has to be implemented in the specific translators.
+			credits: CREDITS_HTML // optional. If available, credits needst to be displayed on site as it may be required by the service terms of use.
+		});
+	 * 
+	 * reject(false); // Will inform this Translator there was an error while processing the translation and it is not available.
+	 */
+	translate(string) {
+		return new Promise((resolve, reject) => {
+			if(!this.loadedTranslator && !this.loadInProgress) {
+				this.load(this.engine).catch(() => {
+					console.error("[Translator] Can't translate", string, "No engine available");
+				});
+			}
+			
+			this.onReady().then((response) => {
+				if(this.loadedTranslator) {
+					this.loadedTranslator.translate(string).then((response) => resolve(response)).catch((reason) => reject(reason));
+				}
+				else {
+					console.error("[Translator] Engine not loaded, could not translate ", string, "using " + this.engine + " engine");
+					reject(false);
+				}
+			}).catch((error) => {
+				if(this.engine !== "default") {
+					console.error("[Translator] Could not translate string", string, "using " + this.engine + " engine");
+					if(!this.loadInProgress) {
+						this.load("default").then((response) => {
+							this.translate(string).then((response) => resolve(response)).catch((reason) => reject(reason));
+						}).catch((reason) => {
+							console.error("[Translator] Could not load default engine");
+						});
+					}
+					else {
+						this.translate(string).then((response) => resolve(response)).catch((reason) => reject(reason));
+					}
+				}
+				else {
+					console.error("[Translator] Could not translate string", string, "using default engine");
+					reject(error);
+				}
+			});
+		});
+	}
+	
+}

--- a/design/translator/generic.js
+++ b/design/translator/generic.js
@@ -114,6 +114,19 @@ class Translator {
 		});
 	}
 	
+	defaultTranslate(string, resolve, reject) {
+		if(!this.loadInProgress) {
+			this.load("default").then((response) => {
+				this.translate(string).then((response) => resolve(response)).catch((reason) => reject(reason));
+			}).catch((reason) => {
+				console.error("[Translator] Could not load default engine");
+			});
+		}
+		else {
+			this.translate(string).then((response) => resolve(response)).catch((reason) => reject(reason));
+		}
+	}
+	
 	/*
 	 * Abstract translate method - every translator needs to implement this and return a promise with a respective translation
 	 * 
@@ -146,16 +159,7 @@ class Translator {
 			}).catch((error) => {
 				if(this.engine !== "default") {
 					console.error("[Translator] Could not translate string", string, "using " + this.engine + " engine");
-					if(!this.loadInProgress) {
-						this.load("default").then((response) => {
-							this.translate(string).then((response) => resolve(response)).catch((reason) => reject(reason));
-						}).catch((reason) => {
-							console.error("[Translator] Could not load default engine");
-						});
-					}
-					else {
-						this.translate(string).then((response) => resolve(response)).catch((reason) => reject(reason));
-					}
+					this.defaultTranslate(string, resolve, reject); // Try default engine
 				}
 				else {
 					console.error("[Translator] Could not translate string", string, "using default engine");

--- a/design/translator/google-translator.js
+++ b/design/translator/google-translator.js
@@ -1,0 +1,188 @@
+"use strict";
+
+class TranslationService {
+	constructor(data) {
+		data = data || {};
+		this.url = data.url || "https://translation.googleapis.com/language/translate/v2";
+		this.apiKey = data.apiKey || "";
+		this.sourceLanguage = data.sourceLanguage || "en";
+		this.destinationLanguage = data.destinationLanguage || "cs";
+		this.dependencies = data.dependencies || [];
+		this.dependencies.push("https://apis.google.com/js/platform.js?onload=loadAuthClient");
+		this.fallback = data.fallback || null;
+		this.forceFallback = data.forceFallback || false;
+		this.credits = "<a href=\"https://translate.google.com/\">Powered by Google Translate</a>";
+		
+		this.ready = false;
+		this.resolves = [];
+		
+		this.clientId = data.clientId || "36f3d9c9569b048082e990528f6af65d26f8e36c";
+		this.idToken = null;
+		
+		this.cachedReplies = {};
+		
+		this.loadDependencies();
+	}
+	
+	logIn() {
+		return new Promise((resolve, reject) => {
+			this.gapi.auth2.init({
+				client_id: this.clientId,
+				scope: "https://www.googleapis.com/auth/userinfo.email"
+			}).then((status) => {
+				console.log("gapi ok", status);
+				
+				this.gapi.auth2.getAuthInstance().signIn().then(() => {
+					let user = this.gapi.auth2.getAuthInstance().currentUser.get();
+					this.idToken = user.getAuthResponse().id_token;
+					resolve(this.idToken);
+				}).catch((error) => {
+					console.log(error);
+					reject(error);
+				});
+			}).catch((error) => {
+				console.error(error);
+				reject(error);
+			});
+		});
+	}
+	
+	loadDependencies() {
+		this.remaining = typeof this.remaining === typeof undefined ? this.dependencies.length : this.remaining;
+		let index = this.dependencies.length - this.remaining;
+		this.loadScript(this.dependencies[index]).then((src) => {
+			this.remaining -= 1;
+			if(this.remaining > 0) {
+				this.loadDependencies();
+			}
+			else {
+				this.gapi = this.gapi || window.gapi;
+				this.gapi.load("auth2", () => {
+					this.logIn().then(() => {
+						this.ready = true;
+						
+						for(let i = 0; i < this.resolves.length; i++) {
+							this.resolves[i].resolve();
+						}
+						this.resolves = [];
+					}).catch(() => {
+						for(let i = 0; i < this.resolves.length; i++) {
+							this.resolves[i].reject();
+						}
+						this.resolves = [];
+					});
+				});
+			}
+		});
+	}
+	
+	loadScript(src) {
+		return new Promise((resolve, reject) => {
+			let existingScriptTags = document.querySelectorAll("script");
+			for(let i = 0; i < existingScriptTags.length; i++) {
+				if(existingScriptTags[i].src === src) {
+					console.log("script already loaded", src);
+					resolve(src);
+					return;
+				}
+			}
+			
+			let newScript = document.createElement("script");
+			newScript.src = src;
+			document.head.appendChild(newScript);
+			newScript.addEventListener("load", (event) => {
+				resolve(src);
+			});
+		});
+	}
+	
+	onReady() {
+		return new Promise((resolve, reject) => {
+			if(this.ready) {
+				resolve();
+			}
+			else {
+				this.resolves.push({
+					resolve,
+					reject
+				});
+			}
+		});
+	}
+	
+	serialize(object) {
+		var serializedString = [];
+		for(let key in object) {
+			if(object.hasOwnProperty(key)) {
+				serializedString.push(encodeURIComponent(key) + "=" + encodeURIComponent(object[key]));
+			}
+		}
+		return serializedString.join("&");
+	}
+	
+	fetch(string) {
+		let data = {
+			q: string,
+			source: this.sourceLanguage,
+			target: this.destinationLanguage
+		};
+		return fetch(this.url, {
+			method: "POST",
+			mode: "cors",
+			headers: {
+				"Authorization": "Bearer " + this.idToken,
+				"Content-type": "application/json; charset=utf-8"
+			},
+			body: this.serialize(data)
+		}).then(response => response.json());
+	}
+	
+	translate(string, forceFetch, forceFallback) {
+		return new Promise((resolve, reject) => {
+			if(!forceFetch && this.cachedReplies[string]) {
+				resolve({
+					text: this.cachedReplies[string].text,
+					lang: this.cachedReplies[string].lang,
+					cached: true,
+					credits: this.credits
+				});
+				return;
+			}
+			
+			this.onReady().then(() => {
+				this.fetch(string).then((response) => {
+					console.log("response", response);
+					if(response.code === 200) {
+						if(response.text) {
+							this.cachedReplies[string] = {
+								text: response.text.join("\n"),
+								lang: response.lang
+							};
+							resolve({
+								text: response.text.join("\n"),
+								lang: response.lang,
+								cached: false,
+								credits: this.credits
+							});
+						}
+					}
+					else {
+						console.error("[TranslationService] Couldn't fetch translation for: \"" + string + "\"");
+						if(response.error) {
+							let keys = Object.keys(response.error);
+							for(let i = 0; i < keys.length; i++) {
+								let status = response.error[keys[i]];
+								if(!Array.isArray(status) && typeof status !== typeof Object) {
+									console.error("[TranslationService] " + keys[i], status);
+								}
+							}
+						}
+						reject(false);
+					}
+				});
+			}).catch((reason) => {
+				reject(reason);
+			});
+		});
+	}
+}

--- a/design/translator/yandex-translator.js
+++ b/design/translator/yandex-translator.js
@@ -1,0 +1,115 @@
+"use strict";
+
+class TranslationService {
+	constructor(data) {
+		data = data || {};
+		this.url = data.url || "https://translate.yandex.net/api/v1.5/tr.json/translate";
+		this.apiKey = data.apiKey || "";
+		this.sourceLanguage = data.sourceLanguage || "en";
+		this.destinationLanguage = data.destinationLanguage || "cs";
+		this.fallback = data.fallback || null;
+		this.forceFallback = data.forceFallback || false;
+		this.credits = "<a href=\"http://translate.yandex.com/\">Powered by Yandex.Translate</a>";
+		
+		this.cachedReplies = {};
+	}
+	
+	serialize(object) {
+		var serializedString = [];
+		for(let key in object) {
+			if(object.hasOwnProperty(key)) {
+				serializedString.push(encodeURIComponent(key) + "=" + encodeURIComponent(object[key]));
+			}
+		}
+		return serializedString.join("&");
+	}
+	
+	fetch(string) {
+		let data = {
+			key: this.apiKey,
+			text: string,
+			format: "plain",
+			lang: this.sourceLanguage + "-" + this.destinationLanguage,
+			options: 1
+		};
+		return fetch(this.url, {
+			method: "POST",
+			mode: "cors",
+			headers: {
+				"Content-type": "application/x-www-form-urlencoded"
+			},
+			body: this.serialize(data)
+		}).then(response => response.json());
+	}
+	
+	fallbackTranslate(string) {
+		console.log("fallbackTranslate");
+		return new Promise((resolve, reject) => {
+			if(this.fallBackTranslator) {
+				this.fallBackTranslator.translate(string).then((data) => resolve(data)).catch((error) => reject(error));
+			}
+			else if(this.fallback) {
+				this.scriptTag = this.scriptTag || document.createElement("script");
+				this.scriptTag.src = this.fallback;
+				document.head.appendChild(this.scriptTag);
+				
+				this.scriptTag.addEventListener("load", (event) => {
+					this.fallBackTranslator = new ENCZTranslator({
+						capitalizeFirst: true
+					});
+					resolve(this.fallBackTranslator.translate(string));
+				});
+			}
+		});
+	}
+	
+	translate(string, forceFetch, forceFallback) {
+		return new Promise((resolve, reject) => {
+			if(this.forceFallback || forceFallback) {
+				this.fallbackTranslate(string).then((data) => resolve(data)).catch((error) => reject(error));
+				return;
+			}
+			
+			if(!forceFetch && this.cachedReplies[string]) {
+				resolve({
+					text: this.cachedReplies[string].text,
+					lang: this.cachedReplies[string].lang,
+					cached: true,
+					credits: this.credits
+				});
+				return;
+			}
+			
+			this.fetch(string).then((response) => {
+				if(response.code === 200) {
+					if(response.text) {
+						this.cachedReplies[string] = {
+							text: response.text.join("\n"),
+							lang: response.lang
+						};
+						resolve({
+							text: response.text.join("\n"),
+							lang: response.lang,
+							cached: false,
+							credits: this.credits
+						});
+					}
+				}
+				else {
+					console.error("[TranslationService] Couldn't fetch translation for: " + string);
+					console.error("[TranslationService] Error Code:", response.code);
+					
+					if(this.fallBackTranslator) {
+						this.fallbackTranslate(string).then((data) => resolve(data)).catch((error) => reject(error));
+					}
+					else if(this.fallback) {
+						this.fallbackTranslate(string).then((data) => resolve(data)).catch((error) => reject(error));
+					}
+					else {
+						reject(false);
+					}
+				}
+			});
+		});
+	}
+}


### PR DESCRIPTION
Tak s tímhle by se měl by default pro překlady používat Yandex. Neměl jsem moc času, takže to není úplně skvělé, ale nějak to funguje.

Jak jsem již zmínil, Yandex vyžaduje uvádění zdroje, takže tam musí být link. A teď se o to stará JS a přidává ho pod každý RSS blok, kde se něco děje. Je otázka, kam to dát jinam, jestli někam do patičky nebo tak, ale velikost písma by neměla být podle podmínek menší, než velikost textu, který je překládaný.

A i když to teď vkládá JS (a zdá se to možná být trochu zbytečné), nechal bych to. Jednak to třeba o to méně bude Google vidět, a potom především ten skript je trochu generický a měl by umožnit přechod třeba i na zatím ne zcela testovaný Google Translate, kde zdroj uvádět netřeba. Takže se prostě zobrazí jen pokud příslušný objekt specifický pro určitou službu bude uvádění zdroje definovat. Nestará se ale o to, kde zdroj vykreslovat, takže přímo v HTML hlavní stránky je možné provést nějakou malou úpravu a tím to vecpat třeba do té patičky.